### PR TITLE
v1.0.0 (upcoming)

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,0 +1,14 @@
+#+TITLE: Changelog
+
+* v1.0.0 (upcoming)
+- Add commands for starring gists: ~igist-star-gist~, ~igist-unstar-gist~ and ~igist-list-starred~
+- Add custom variable ~igist-enable-copy-gist-url~ to control whether to copy gists URL after creating or editing
+- Update layout and keys for transient. Transient commands are now bound to single keys.
+- Change keybinding for ~igist-browse-gist~ from =b= to =r=
+- Remove separate variable for another user name as it can be accessed from ~igist-list-other-user-gists~ history
+- Setup temporarly ~buffer-file-name~ for gists in edit buffers.
+- Allow major mode hooks in edit mode.
+- Run ~before-save-hook~ before posting gists
+- Speedup ~igist-explore-public-gists~
+- Fix removing comments
+- Fix running ~igist-before-save-hook~

--- a/README.md
+++ b/README.md
@@ -5,20 +5,32 @@ The Emacs everywhere goal continues. These are the main features of
 
 ![](./igist-demo.gif)
 
-  - Edit a gist
-  - List gists
-  - Create a gist
-  - Delete a gist
-  - Fork a gist
-  - Edit, view, list, and create comments
-  - UI
-      - transient api
-      - tabulated/minibuffer display
-  - auth-sources support
+## Features
+
+### Gists
+
+  - \[X\] create
+  - \[X\] edit
+  - \[X\] delete
+  - \[X\] star
+  - \[X\] unstar
+  - \[X\] fork
+  - \[X\] list
+  - \[X\] explore public gists
+
+### Comments
+
+  - \[X\] add
+  - \[X\] list
+  - \[X\] delete
+  - \[X\] edit
 
 # igist
 
 >   - [About](#about)
+>       - [Features](#features)
+>           - [Gists](#gists)
+>           - [Comments](#comments)
 >       - [Requirements](#requirements)
 >       - [Installation](#installation)
 >           - [Manually](#manually)
@@ -75,35 +87,40 @@ Download the repository and it to your load path in your init file:
              :type git
              :host github)
   :bind (("M-o" . igist-dispatch)
+         (:map igist-list-mode-map
+               ("C-j" . igist-list-view-current)
+               ("RET" . igist-list-edit-gist-at-point)
+               ("+" . igist-list-add-file)
+               ("-" . igist-delete-current-filename)
+               ("D" . igist-delete-current-gist)
+               ("K" . igist-list-cancel-load)
+               ("S" . igist-star-gist)
+               ("U" . igist-unstar-gist)
+               ("a" . igist-add-comment)
+               ("c" . igist-load-comments)
+               ("d" . igist-list-edit-description)
+               ("f" . igist-fork-gist)
+               ("g" . igist-list-refresh)
+               ("r" . igist-browse-gist)
+               ("v" . igist-list-view-current)
+               ("w" . igist-copy-gist-url))
          (:map igist-edit-mode-map
                ([remap save-buffer] . igist-save-current-gist)
                ("M-o" . igist-dispatch)
                ("C-c C-c" . igist-save-current-gist-and-exit)
                ("C-c C-k" . kill-current-buffer)
                ("C-c '" . igist-save-current-gist-and-exit))
-         (:map igist-list-mode-map
-               ("C-j" . igist-list-view-current)
-               ("RET" . igist-list-view-current)
-               ("+" . igist-list-add-file)
-               ("-" . igist-delete-current-filename)
-               ("D" . igist-delete-current-gist)
-               ("a" . igist-add-comment)
-               ("c" . igist-load-comments)
-               ("e" . igist-list-edit-description)
-               ("f" . igist-fork-gist)
-               ("g" . igist-list-gists)
-               ("v" . igist-list-view-current)
-               ("b" . igist-browse-gist)
-         (:map igist-comments-edit-mode-map
-               ("M-o" . igist-dispatch)
-               ("C-c C-c" . igist-post-comment)
-               ("C-c C-k" . kill-current-buffer))
          (:map igist-comments-list-mode-map
                ("+" . igist-add-comment)
                ("-" . igist-delete-comment-at-point)
                ("D" . igist-delete-comment-at-point)
                ("e" . igist-add-or-edit-comment)
-               ("g" . igist-load-comments))))
+               ("g" . igist-load-comments)
+               ("q" . kill-current-buffer))
+         (:map igist-comments-edit-mode-map
+               ("M-o" . igist-dispatch)
+               ("C-c C-c" . igist-post-comment)
+               ("C-c C-k" . kill-current-buffer))))
 ```
 </details>
 
@@ -163,20 +180,24 @@ minibuffer completions.
     pause loading use command `igist-list-cancel-load` (default
     keybinding is `K`).
     
-    | Key | Command        |
-    | --- | -------------- |
-    | C-j | view gist      |
-    | v   | view gist      |
-    | RET | edit gist      |
-    | \-  | delete file    |
-    | \+  | add file       |
-    | D   | delete gist    |
-    | c   | load comments  |
-    | a   | add comment    |
-    | g   | refresh gists  |
-    | f   | fork gist      |
-    | b   | browse gist    |
-    | K   | cancel loading |
+    | Key | Command                       |
+    | --- | ----------------------------- |
+    | C-j | igist-list-view-current       |
+    | RET | igist-list-edit-gist-at-point |
+    | \+  | igist-list-add-file           |
+    | \-  | igist-delete-current-filename |
+    | D   | igist-delete-current-gist     |
+    | K   | igist-list-cancel-load        |
+    | S   | igist-star-gist               |
+    | U   | igist-unstar-gist             |
+    | a   | igist-add-comment             |
+    | c   | igist-load-comments           |
+    | d   | igist-list-edit-description   |
+    | f   | igist-fork-gist               |
+    | g   | igist-list-refresh            |
+    | r   | igist-browse-gist             |
+    | v   | igist-list-view-current       |
+    | w   | igist-copy-gist-url           |
     
 
     To customize these keys, see the variable `igist-list-mode-map`.

--- a/README.org
+++ b/README.org
@@ -8,20 +8,28 @@ The Emacs everywhere goal continues. These are the main features of
 
 [[./igist-demo.gif]]
 
-- Edit a gist
-- List gists
-- Create a gist
-- Delete a gist
-- Fork a gist
-- Edit, view, list, and create comments
-- UI
-  - transient api
-  - tabulated/minibuffer display
-- auth-sources support
+** Features
+*** Gists
+- [X] create
+- [X] edit
+- [X] delete
+- [X] star
+- [X] unstar
+- [X] fork
+- [X] list
+- [X] explore public gists
+*** Comments
+- [X] add
+- [X] list
+- [X] delete
+- [X] edit
 
 * igist                                                            :TOC_3_gh:QUOTE:
 #+BEGIN_QUOTE
 - [[#about][About]]
+  - [[#features][Features]]
+    - [[#gists][Gists]]
+    - [[#comments][Comments]]
   - [[#requirements][Requirements]]
   - [[#installation][Installation]]
     - [[#manually][Manually]]
@@ -78,35 +86,40 @@ Download the repository and it to your load path in your init file:
              :type git
              :host github)
   :bind (("M-o" . igist-dispatch)
+         (:map igist-list-mode-map
+               ("C-j" . igist-list-view-current)
+               ("RET" . igist-list-edit-gist-at-point)
+               ("+" . igist-list-add-file)
+               ("-" . igist-delete-current-filename)
+               ("D" . igist-delete-current-gist)
+               ("K" . igist-list-cancel-load)
+               ("S" . igist-star-gist)
+               ("U" . igist-unstar-gist)
+               ("a" . igist-add-comment)
+               ("c" . igist-load-comments)
+               ("d" . igist-list-edit-description)
+               ("f" . igist-fork-gist)
+               ("g" . igist-list-refresh)
+               ("r" . igist-browse-gist)
+               ("v" . igist-list-view-current)
+               ("w" . igist-copy-gist-url))
          (:map igist-edit-mode-map
                ([remap save-buffer] . igist-save-current-gist)
                ("M-o" . igist-dispatch)
                ("C-c C-c" . igist-save-current-gist-and-exit)
                ("C-c C-k" . kill-current-buffer)
                ("C-c '" . igist-save-current-gist-and-exit))
-         (:map igist-list-mode-map
-               ("C-j" . igist-list-view-current)
-               ("RET" . igist-list-view-current)
-               ("+" . igist-list-add-file)
-               ("-" . igist-delete-current-filename)
-               ("D" . igist-delete-current-gist)
-               ("a" . igist-add-comment)
-               ("c" . igist-load-comments)
-               ("e" . igist-list-edit-description)
-               ("f" . igist-fork-gist)
-               ("g" . igist-list-gists)
-               ("v" . igist-list-view-current)
-               ("b" . igist-browse-gist)
-         (:map igist-comments-edit-mode-map
-               ("M-o" . igist-dispatch)
-               ("C-c C-c" . igist-post-comment)
-               ("C-c C-k" . kill-current-buffer))
          (:map igist-comments-list-mode-map
                ("+" . igist-add-comment)
                ("-" . igist-delete-comment-at-point)
                ("D" . igist-delete-comment-at-point)
                ("e" . igist-add-or-edit-comment)
-               ("g" . igist-load-comments))))
+               ("g" . igist-load-comments)
+               ("q" . kill-current-buffer))
+         (:map igist-comments-edit-mode-map
+               ("M-o" . igist-dispatch)
+               ("C-c C-c" . igist-post-comment)
+               ("C-c C-k" . kill-current-buffer))))
 ```
 </details>
 #+end_export
@@ -152,20 +165,26 @@ There are two ways in which gists can be presented - as a table or as minibuffer
 
 This commands render and load gists with pagination. To stop or pause loading use command ~igist-list-cancel-load~ (default keybinding is ~K~).
 
-| Key | Command        |
-|-----+----------------|
-| C-j | view gist      |
-| v   | view gist      |
-| RET | edit gist      |
-| -   | delete file    |
-| +   | add file       |
-| D   | delete gist    |
-| c   | load comments  |
-| a   | add comment    |
-| g   | refresh gists  |
-| f   | fork gist      |
-| b   | browse gist    |
-| K   | cancel loading |
+
+| Key | Command                       |
+|-----+-------------------------------|
+| C-j | igist-list-view-current       |
+| RET | igist-list-edit-gist-at-point |
+| +   | igist-list-add-file           |
+| -   | igist-delete-current-filename |
+| D   | igist-delete-current-gist     |
+| K   | igist-list-cancel-load        |
+| S   | igist-star-gist               |
+| U   | igist-unstar-gist             |
+| a   | igist-add-comment             |
+| c   | igist-load-comments           |
+| d   | igist-list-edit-description   |
+| f   | igist-fork-gist               |
+| g   | igist-list-refresh            |
+| r   | igist-browse-gist             |
+| v   | igist-list-view-current       |
+| w   | igist-copy-gist-url           |
+
 
 To customize these keys, see the variable =igist-list-mode-map=.
 

--- a/igist.el
+++ b/igist.el
@@ -2206,16 +2206,8 @@ If BACKGROUND is nil, don't show user's buffer."
 ;;;###autoload
 (defun igist-list-other-user-gists (user)
   "List public gists of USER."
-  (interactive (read-string "User: "))
+  (interactive (list (read-string "User: ")))
   (igist-list-load-gists user nil))
-
-(defun igist-list-change-other-user (&optional prompt input history)
-  "Read owner of gists to load in minibuffer with PROMPT, INPUT and HISTORY."
-  (setq igist-other-username (read-string (or prompt "User: ") input history))
-  (unless (string-empty-p igist-other-username)
-    (igist-list-other-user-gists
-     igist-other-username))
-  igist-other-username)
 
 ;;;###autoload
 (defun igist-delete-other-gist-or-file (gist)

--- a/igist.el
+++ b/igist.el
@@ -2612,18 +2612,19 @@ If ACTION is non nil, call it with gist."
 
 (defun igist-not-editable-p (&optional gist)
   "Return t if user `igist-current-user-name' cannot edit GIST."
-  (if-let ((owner
-            (igist-get-owner
-             (or gist
-                 (igist-tabulated-gist-at-point)
-                 igist-current-gist))))
-      (not
-       (equal igist-current-user-name owner))
-    (not igist-current-user-name)))
+  (not (igist-editable-p gist)))
 
 (defun igist-editable-p (&optional gist)
   "Check whether user `igist-current-user-name' can edit GIST."
-  (not (igist-not-editable-p gist)))
+  (when-let* ((id (and igist-current-user-name
+                       (igist-alist-get 'id (or gist
+                                                (igist-tabulated-gist-at-point)
+                                                igist-current-gist))))
+              (buffer (igist-get-user-buffer igist-current-user-name)))
+    (igist-alist-find-by-prop 'id id
+                              (when (buffer-live-p buffer)
+                                (buffer-local-value
+                                 'igist-list-response buffer)))))
 
 (defun igist-forkable (&optional gist)
   "Return t if user `igist-current-user-name' can fork GIST."

--- a/igist.el
+++ b/igist.el
@@ -2375,18 +2375,15 @@ If BACKGROUND is nil, don't show user's buffer."
                           (buffer-substring-no-properties (point-min)
                                                           (point-max)))))
     (let ((filename (read-string "Filename: "
-                                 (when buffer-file-name
-                                   (if-let ((ext
-                                             (file-name-extension
-                                              buffer-file-name)))
-                                       (concat
-                                        (file-name-base
-                                         buffer-file-name)
-                                        "." ext))))))
+                                 (if buffer-file-name
+                                     (file-name-nondirectory buffer-file-name)
+                                   (buffer-name)))))
       (pop-to-buffer
        (igist-setup-new-gist-buffer filename content)
        nil
        t))))
+
+
 
 ;;;###autoload
 (defun igist-create-new-gist ()

--- a/igist.el
+++ b/igist.el
@@ -2561,7 +2561,8 @@ If ACTION is non nil, call it with gist."
   :reader #'igist-toggle-public
   :argument "affirmative")
 
-(transient-define-prefix igist-dispatch-transient ()
+;;;###autoload (autoload 'igist-dispatch "igist" nil t)
+(transient-define-prefix igist-dispatch ()
   "Transient menu for gists."
   :transient-non-suffix #'transient--do-stay
   [[:if-mode
@@ -2634,11 +2635,6 @@ If ACTION is non nil, call it with gist."
    ("o" igist-transient-change-owner)
    ("q" "Quit" transient-quit-all)])
 
-;;;###autoload
-(defun igist-dispatch ()
-  "Dispatch transient API with available gists commands for current buffer."
-  (interactive)
-  (funcall-interactively #'igist-dispatch-transient))
 
 (provide 'igist)
 ;;; igist.el ends here

--- a/igist.el
+++ b/igist.el
@@ -887,7 +887,6 @@ GIST should be raw GitHub item."
     (cdr (igist-normalize-gist-file gist filename))))
 
 
-;;;###autoload
 (defun igist-copy-gist-url ()
   "Copy url of gist at point or currently open."
   (interactive)
@@ -898,7 +897,6 @@ GIST should be raw GitHub item."
     (kill-new gist-url)
     (message "Copied %s" gist-url)))
 
-;;;###autoload
 (defun igist-browse-gist ()
   "Browse gist at point or currently open."
   (interactive)
@@ -921,7 +919,6 @@ GIST should be raw GitHub item."
                                                                parent)))))
           (igist-read-gist-file "Filename: " parent)))))
 
-;;;###autoload
 (defun igist-list-edit-gist-at-point (&optional _entry)
   "Switch to the buffer with the content of a gist entry at the point."
   (interactive)
@@ -929,8 +926,6 @@ GIST should be raw GitHub item."
     (let ((buff (igist-setup-edit-buffer gist)))
       (switch-to-buffer-other-window buff))))
 
-
-;;;###autoload
 (defun igist-list-view-current ()
   "Display content of a gist entry at the point without switching to buffer."
   (interactive)
@@ -940,7 +935,6 @@ GIST should be raw GitHub item."
       (let ((buff (igist-setup-edit-buffer gist)))
         (switch-to-buffer-other-window buff)))))
 
-;;;###autoload
 (defun igist-explore-load-other-user-gists (&rest _)
   "List public gists of owner gist entry at point."
   (interactive)
@@ -951,7 +945,6 @@ GIST should be raw GitHub item."
                       user))
       (igist-list-load-gists user))))
 
-;;;###autoload
 (defun igist-list-edit-description (&rest _)
   "Edit description for current gist."
   (interactive)
@@ -1280,7 +1273,6 @@ If LOADING is non nil show spinner, otherwise hide."
                        (if msg (concat ":\s" msg) "")))
     (igist-message "Igist: request error: %s" value)))
 
-;;;###autoload
 (defun igist-star-gist ()
   "Star currently viewing gist or gist at point."
   (interactive)
@@ -1295,7 +1287,6 @@ If LOADING is non nil show spinner, otherwise hide."
                        (igist-message "Gist starred")))
     (user-error "No gist")))
 
-;;;###autoload
 (defun igist-unstar-gist ()
   "Unstar currently viewing gist or gist at point."
   (interactive)
@@ -1310,8 +1301,6 @@ If LOADING is non nil show spinner, otherwise hide."
                        (igist-message "Gist unstarred")))
     (user-error "No gist")))
 
-
-;;;###autoload
 (defun igist-fork-gist ()
   "Fork the current gist."
   (interactive)
@@ -1738,7 +1727,6 @@ GIST-ID is used to create comments buffer."
         (setq igist-comment-gist-id gist-id)
         (pop-to-buffer (current-buffer))))))
 
-;;;###autoload
 (defun igist-load-comments (&rest _)
   "Load comments for gist at point or edit buffer."
   (interactive)
@@ -1801,7 +1789,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
                (apply fn args))
       (delete-overlay overlay))))
 
-;;;###autoload
 (defun igist-add-comment ()
   "Add a new comment for the current gist."
   (interactive)
@@ -1819,7 +1806,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
    (get-text-property (point) 'igist-comment-gist-id)
    (igist-alist-get 'id igist-current-gist)))
 
-;;;###autoload
 (defun igist-add-or-edit-comment (&rest _)
   "Add or edit comment for gist at point or edit buffer."
   (interactive)
@@ -1837,7 +1823,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
       (pop-to-buffer-same-window (igist-setup-comment-buffer
                                   gist-id)))))
 
-;;;###autoload
 (defun igist-delete-comment-at-point (&rest _)
   "Add or edit a comment for gist at point or edit buffer."
   (interactive)
@@ -1866,7 +1851,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
                                   (igist-load-logged-user-gists))))
     (user-error "Not in gist comment")))
 
-;;;###autoload
 (defun igist-post-comment ()
   "Save the currently edited or created comment."
   (interactive)
@@ -1898,7 +1882,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
                   :callback callback-fn
                   :payload `((body . ,content))))))
 
-;;;###autoload
 (defun igist-list-add-file ()
   "Add a new file name to current gist at the point."
   (interactive)
@@ -1919,50 +1902,6 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
                           gist)))))
       (switch-to-buffer-other-window buff))))
 
-;;;###autoload
-(defun igist-list-gists ()
-  "Load and render gists for user specified in `igist-current-user-name'."
-  (interactive)
-  (unless igist-current-user-name
-    (igist-change-user))
-  (igist-list-load-gists
-   igist-current-user-name nil))
-
-;;;###autoload
-(defun igist-new-gist-from-buffer ()
-  "Create the editable gist buffer with the content of the current buffer."
-  (interactive)
-  (when-let ((content (or (igist-get-region-content)
-                          (buffer-substring-no-properties (point-min)
-                                                          (point-max)))))
-    (let ((filename (read-string "Filename: "
-                                 (when buffer-file-name
-                                   (if-let ((ext
-                                             (file-name-extension
-                                              buffer-file-name)))
-                                       (concat
-                                        (file-name-base
-                                         buffer-file-name)
-                                        "." ext))))))
-      (pop-to-buffer
-       (igist-setup-new-gist-buffer filename content)
-       nil
-       t))))
-
-;;;###autoload
-(defun igist-create-new-gist ()
-  "Set up and switch to the editable gist buffer.
-If Transient Mark mode is enabled and the mark is active,
-insert it as initial content."
-  (interactive)
-  (let ((region-content (igist-get-region-content)))
-    (let ((filename (read-string "Filename: "
-                                 (when region-content
-                                   (igist-suggest-filename)))))
-      (pop-to-buffer (igist-setup-new-gist-buffer filename
-                                                  (or region-content ""))))))
-
-;;;###autoload
 (defun igist-kill-all-gists-buffers ()
   "Delete all gists buffers."
   (interactive)
@@ -1971,44 +1910,6 @@ insert it as initial content."
       (with-current-buffer buff
         (set-buffer-modified-p nil))
       (kill-buffer buff))))
-
-;;;###autoload
-(defun igist-change-user (&optional prompt initial-input history)
-  "Read a user in the minibuffer with PROMPT, INITIAL-INPUT, and HISTORY."
-  (interactive)
-  (let ((user
-         (if (stringp igist-auth-marker)
-             (read-string (or prompt "User: ") initial-input history)
-           (let* ((alist (mapcar (lambda (it)
-                                   (let ((parts (split-string it "[\\^]" t)))
-                                     (cons (pop parts)
-                                           (pop parts))))
-                                 (igist-get-github-users)))
-                  (annotf (lambda (str)
-                            (format "^%s" (cdr (assoc str alist)))))
-                  (login-name (completing-read (or prompt
-                                                   "Github user name: ")
-                                               (lambda (str pred action)
-                                                 (if (eq action 'metadata)
-                                                     `(metadata
-                                                       (annotation-function
-                                                        . ,annotf))
-                                                   (complete-with-action
-                                                    action alist
-                                                    str
-                                                    pred)))
-                                               nil
-                                               nil
-                                               initial-input
-                                               history))
-                  (marker (igist-alist-get login-name alist)))
-             (when-let ((marker (and marker (intern marker))))
-               (unless (eq marker igist-auth-marker)
-                 (setq igist-auth-marker marker)))
-             login-name))))
-    (if (string-empty-p user)
-        nil
-      user)))
 
 (defun igist-list-get-per-page-query (buffer)
   "Return estimed gists count for BUFFER."
@@ -2025,14 +1926,12 @@ insert it as initial content."
      estimed-gists-count
      100)))
 
-;;;###autoload
 (defun igist-list-cancel-load ()
   "Cancel loading for current gists."
   (interactive)
   (setq igist-list-cancelled t)
   (igist-spinner-stop))
 
-;;;###autoload
 (defun igist-list-refresh ()
   "Refresh gists in the current `igist-list-mode' buffer."
   (interactive)
@@ -2103,18 +2002,15 @@ REQ is a `ghub--req' struct, used for loading next page."
     (cancel-timer igist-render-timer))
   (setq igist-render-timer nil))
 
-;;;###autoload
-(defun igist-explore-public-gists (&optional background)
-  "List public gists sorted by most recently updated to least recently updated.
+(defun igist-list-load-gists (user &optional background callback callback-args)
+  "List USER's gists sorted by most recently updated to least recently updated.
 
-Render and load up to 3000 gists with pagination.
-
+Then execute CALLBACK with CALLBACK-ARGS.
 To stop or pause loading use command `igist-list-cancel-load'.
 
-If BACKGROUND is non-nil, don't show buffer."
-  (interactive)
-  (igist-list-request "/gists/public" nil
-                      background))
+If BACKGROUND is nil, don't show user's buffer."
+  (igist-list-request
+   (concat "/users/" user "/gists") user background callback callback-args))
 
 (defun igist-load-logged-user-gists (&optional cb &rest args)
   "Load gists asynchronously with callback CB and ARGS."
@@ -2123,7 +2019,6 @@ If BACKGROUND is non-nil, don't show buffer."
   (igist-list-load-gists igist-current-user-name
                          t
                          cb args))
-
 
 (defun igist-list-request (url user &optional background callback callback-args)
   "Request URL to list USER's gists with pagination.
@@ -2178,35 +2073,6 @@ If BACKGROUND is nil, don't show user's buffer."
         (unless background
           (igist-ensure-buffer-visible buffer))))))
 
-;;;###autoload
-(defun igist-list-starred ()
-  "List the authenticated user's starred gists with pagination.
-
-Then execute CALLBACK with CALLBACK-ARGS.
-To stop or pause loading use command `igist-list-cancel-load'.
-
-If BACKGROUND is nil, don't show user's buffer."
-  (interactive)
-  (igist-list-request "/gists/starred"
-                      igist-current-user-name))
-
-(defun igist-list-load-gists (user &optional background callback callback-args)
-  "List USER's gists sorted by most recently updated to least recently updated.
-
-Then execute CALLBACK with CALLBACK-ARGS.
-To stop or pause loading use command `igist-list-cancel-load'.
-
-If BACKGROUND is nil, don't show user's buffer."
-  (igist-list-request
-   (concat "/users/" user "/gists") user background callback callback-args))
-
-;;;###autoload
-(defun igist-list-other-user-gists (user)
-  "List public gists of USER."
-  (interactive (list (read-string "User: ")))
-  (igist-list-load-gists user nil))
-
-;;;###autoload
 (defun igist-delete-other-gist-or-file (gist)
   "Delete GIST with id."
   (interactive
@@ -2234,7 +2100,7 @@ If BACKGROUND is nil, don't show user's buffer."
        (igist-delete-gists-buffers-by-id id)
        (igist-request-delete id)))))
 
-;;;###autoload
+
 (defun igist-delete-current-filename ()
   "Delete the current file from the gist."
   (interactive)
@@ -2264,7 +2130,7 @@ If BACKGROUND is nil, don't show user's buffer."
                                         parent)))))
     (igist-request-delete-filename confirmed-gist)))
 
-;;;###autoload
+
 (defun igist-delete-current-gist ()
   "Delete the current gist with all files."
   (interactive)
@@ -2286,13 +2152,13 @@ If BACKGROUND is nil, don't show user's buffer."
              (igist-delete-gists-buffers-by-id id)
              (igist-request-delete id))))))
 
-;;;###autoload
+
 (defun igist-toggle-public (&rest _)
   "Toggle value of variable `igist-current-public'."
   (interactive)
   (setq igist-current-public (not igist-current-public)))
 
-;;;###autoload
+
 (defun igist-add-file-to-gist ()
   "Add a new file to the existing gist."
   (interactive)
@@ -2324,7 +2190,6 @@ If BACKGROUND is nil, don't show user's buffer."
            (pop-to-buffer
             (igist-setup-edit-buffer data))))))
 
-;;;###autoload
 (defun igist-read-description (&rest _args)
   "Update description for current gist without saving."
   (interactive)
@@ -2340,7 +2205,6 @@ If BACKGROUND is nil, don't show user's buffer."
                                              igist-current-gist)))))
       (setq igist-current-description descr))))
 
-;;;###autoload
 (defun igist-read-filename (&rest _args)
   "Update the filename for the current gist without saving."
   (interactive)
@@ -2376,7 +2240,7 @@ With CALLBACK call it without args after success request."
     (when (igist-gist-modified-p buffer)
       (igist-save-existing-gist buffer callback))))
 
-;;;###autoload
+
 (defun igist-save-current-gist ()
   "Post the current gist and stay in the buffer."
   (interactive)
@@ -2384,7 +2248,7 @@ With CALLBACK call it without args after success request."
                           (lambda ()
                             (igist-message "Gist saved"))))
 
-;;;###autoload
+
 (defun igist-save-current-gist-and-exit ()
   "Post current gist and exit."
   (interactive)
@@ -2393,56 +2257,6 @@ With CALLBACK call it without args after success request."
                             (kill-buffer (buffer-name))
                             (igist-message "Gist created"))))
 
-;;;###autoload
-(define-minor-mode igist-comments-edit-mode
-  "Minor mode for editing and creating gists comments.
-
-This minor mode is turned on after commands `igist-add-comment'
-and `igist-edit-comment'.
-
-\\<igist-comments-edit-mode-map>
-\\{igist-comments-edit-mode-map}."
-  :lighter " Igist"
-  :keymap igist-comments-edit-mode-map
-  :global nil
-  (when igist-comments-edit-mode
-    (pcase igist-mode-for-comments
-      ('org-mode
-       (when (not (executable-find "pandoc"))
-         (error "You must install pandoc to use org-mode for gists")
-         (org-mode)))
-      ((pred functionp)
-       (funcall igist-mode-for-comments)))
-    (use-local-map
-     (let ((map (copy-keymap
-                 igist-comments-edit-mode-map)))
-       (set-keymap-parent map (current-local-map))
-       map))))
-
-;;;###autoload
-(define-minor-mode igist-edit-mode
-  "Minor mode for language major mode buffers generated by `igist'.
-
-This minor mode is turned on after command `igist-edit-gist'.
-
-\\<igist-edit-mode-map>
-\\{igist-edit-mode-map}
-
-See also `igist-before-save-hook'."
-  :lighter " Igist"
-  :keymap igist-edit-mode-map
-  :global nil
-  (when igist-edit-mode
-    (progn
-      (setq buffer-read-only nil)
-      (set-buffer-modified-p nil)
-      (use-local-map
-       (let ((map (copy-keymap
-                   igist-edit-mode-map)))
-         (set-keymap-parent map (current-local-map))
-         map)))))
-
-;;;###autoload
 (defun igist-completing-read-gists (&optional prompt action initial-input)
   "Read gist in minibuffer with PROMPT and INITIAL-INPUT.
 If ACTION is non nil, call it with gist."
@@ -2503,6 +2317,169 @@ If ACTION is non nil, call it with gist."
   (igist-load-logged-user-gists #'igist-completing-read-gists
                                 "Edit gist\s"
                                 #'igist-edit-gist))
+
+;;;###autoload
+(defun igist-explore-public-gists (&optional background)
+  "List public gists sorted by most recently updated to least recently updated.
+
+Render and load up to 3000 gists with pagination.
+
+To stop or pause loading use command `igist-list-cancel-load'.
+
+If BACKGROUND is non-nil, don't show buffer."
+  (interactive)
+  (igist-list-request "/gists/public" nil
+                      background))
+
+;;;###autoload
+(defun igist-list-starred ()
+  "List the authenticated user's starred gists with pagination.
+
+Then execute CALLBACK with CALLBACK-ARGS.
+To stop or pause loading use command `igist-list-cancel-load'.
+
+If BACKGROUND is nil, don't show user's buffer."
+  (interactive)
+  (igist-list-request "/gists/starred"
+                      igist-current-user-name))
+
+;;;###autoload
+(defun igist-list-other-user-gists (user)
+  "List public gists of USER."
+  (interactive (list (read-string "User: ")))
+  (igist-list-load-gists user nil))
+
+;;;###autoload
+(defun igist-list-gists ()
+  "Load and render gists for user specified in `igist-current-user-name'."
+  (interactive)
+  (unless igist-current-user-name
+    (igist-change-user))
+  (igist-list-load-gists
+   igist-current-user-name nil))
+
+;;;###autoload
+(defun igist-new-gist-from-buffer ()
+  "Create the editable gist buffer with the content of the current buffer."
+  (interactive)
+  (when-let ((content (or (igist-get-region-content)
+                          (buffer-substring-no-properties (point-min)
+                                                          (point-max)))))
+    (let ((filename (read-string "Filename: "
+                                 (when buffer-file-name
+                                   (if-let ((ext
+                                             (file-name-extension
+                                              buffer-file-name)))
+                                       (concat
+                                        (file-name-base
+                                         buffer-file-name)
+                                        "." ext))))))
+      (pop-to-buffer
+       (igist-setup-new-gist-buffer filename content)
+       nil
+       t))))
+
+;;;###autoload
+(defun igist-create-new-gist ()
+  "Set up and switch to the editable gist buffer.
+If Transient Mark mode is enabled and the mark is active,
+insert it as initial content."
+  (interactive)
+  (let ((region-content (igist-get-region-content)))
+    (let ((filename (read-string "Filename: "
+                                 (when region-content
+                                   (igist-suggest-filename)))))
+      (pop-to-buffer (igist-setup-new-gist-buffer filename
+                                                  (or region-content ""))))))
+
+;;;###autoload
+(defun igist-change-user (&optional prompt initial-input history)
+  "Read a user in the minibuffer with PROMPT, INITIAL-INPUT, and HISTORY."
+  (interactive)
+  (let ((user
+         (if (stringp igist-auth-marker)
+             (read-string (or prompt "User: ") initial-input history)
+           (let* ((alist (mapcar (lambda (it)
+                                   (let ((parts (split-string it "[\\^]" t)))
+                                     (cons (pop parts)
+                                           (pop parts))))
+                                 (igist-get-github-users)))
+                  (annotf (lambda (str)
+                            (format "^%s" (cdr (assoc str alist)))))
+                  (login-name (completing-read (or prompt
+                                                   "Github user name: ")
+                                               (lambda (str pred action)
+                                                 (if (eq action 'metadata)
+                                                     `(metadata
+                                                       (annotation-function
+                                                        . ,annotf))
+                                                   (complete-with-action
+                                                    action alist
+                                                    str
+                                                    pred)))
+                                               nil
+                                               nil
+                                               initial-input
+                                               history))
+                  (marker (igist-alist-get login-name alist)))
+             (when-let ((marker (and marker (intern marker))))
+               (unless (eq marker igist-auth-marker)
+                 (setq igist-auth-marker marker)))
+             login-name))))
+    (if (string-empty-p user)
+        nil
+      user)))
+
+
+;;;###autoload
+(define-minor-mode igist-comments-edit-mode
+  "Minor mode for editing and creating gists comments.
+
+This minor mode is turned on after commands `igist-add-comment'
+and `igist-edit-comment'.
+
+\\<igist-comments-edit-mode-map>
+\\{igist-comments-edit-mode-map}."
+  :lighter " Igist"
+  :keymap igist-comments-edit-mode-map
+  :global nil
+  (when igist-comments-edit-mode
+    (pcase igist-mode-for-comments
+      ('org-mode
+       (when (not (executable-find "pandoc"))
+         (error "You must install pandoc to use org-mode for gists")
+         (org-mode)))
+      ((pred functionp)
+       (funcall igist-mode-for-comments)))
+    (use-local-map
+     (let ((map (copy-keymap
+                 igist-comments-edit-mode-map)))
+       (set-keymap-parent map (current-local-map))
+       map))))
+
+;;;###autoload
+(define-minor-mode igist-edit-mode
+  "Minor mode for language major mode buffers generated by `igist'.
+
+This minor mode is turned on after command `igist-edit-gist'.
+
+\\<igist-edit-mode-map>
+\\{igist-edit-mode-map}
+
+See also `igist-before-save-hook'."
+  :lighter " Igist"
+  :keymap igist-edit-mode-map
+  :global nil
+  (when igist-edit-mode
+    (progn
+      (setq buffer-read-only nil)
+      (set-buffer-modified-p nil)
+      (use-local-map
+       (let ((map (copy-keymap
+                   igist-edit-mode-map)))
+         (set-keymap-parent map (current-local-map))
+         map)))))
+
 
 ;; Transient
 (transient-define-argument igist-set-current-filename-variable ()

--- a/igist.el
+++ b/igist.el
@@ -330,7 +330,6 @@ Should accept the same arguments as `message'."
           (function :tag "Function"))
   :group 'igist)
 
-
 (defvar igist-before-save-hook '()
   "A list of hooks run before posting gist.")
 
@@ -2486,7 +2485,6 @@ See also `igist-before-save-hook'."
          (set-keymap-parent map (current-local-map))
          map)))))
 
-
 ;; Transient
 (transient-define-argument igist-set-current-filename-variable ()
   "Set a Lisp variable, `igist-current-filename'."
@@ -2505,10 +2503,9 @@ See also `igist-before-save-hook'."
   "Read user name and assign it in the variable `igist-current-user-name'."
   :description "Login Name"
   :class 'transient-lisp-variable
-  :shortarg "-u"
   :variable 'igist-current-user-name
-  :reader #'igist-change-user
-  :argument "--user=")
+  :argument "--user"
+  :reader #'igist-change-user)
 
 (transient-define-argument igist-set-current-description-variable ()
   "Read description and assign it in the variable `igist-current-description'."
@@ -2517,17 +2514,22 @@ See also `igist-before-save-hook'."
                   (or igist-current-filename
                       igist-current-gist))
   :class 'transient-lisp-variable
+  :always-read t
   :reader #'igist-read-description
-  :shortarg "-f"
-  :variable 'igist-current-description
-  :argument "--description=")
+  :argument "--description"
+  :variable 'igist-current-description)
 
 (transient-define-argument igist-transient-toggle-public ()
   "Toggle gist visibility and assign it in the variable `igist-current-public'."
   :description "Public"
-  :inapt-if #'igist-get-current-gist-id
+  :if-not #'igist-get-current-gist-id
+  :always-read t
   :class 'transient-lisp-variable
-  :shortarg "-p"
+  :init-value (lambda (ob)
+                (setf
+                 (slot-value ob 'value)
+                 igist-current-public))
+  :shortarg "-P"
   :variable 'igist-current-public
   :reader #'igist-toggle-public
   :argument "affirmative")
@@ -2538,79 +2540,79 @@ See also `igist-before-save-hook'."
   :transient-non-suffix #'transient--do-stay
   [[:if-mode
     igist-list-mode
-    "Actions"
-    ("RET" "edit" igist-list-edit-gist-at-point :inapt-if-not
+    "Gist at point"
+    ("RET" "Edit" igist-list-edit-gist-at-point :inapt-if-not
      tabulated-list-get-id)
-    ("v" "view" igist-list-view-current :inapt-if-not tabulated-list-get-id)
-    ("f" "fork" igist-fork-gist :inapt-if-not igist-forkable)
-    ("w" "copy url" igist-copy-gist-url :inapt-if-not tabulated-list-get-id)
-    ("r" "browse" igist-browse-gist :inapt-if-not tabulated-list-get-id)
-    ("S" "star" igist-star-gist :inapt-if-not tabulated-list-get-id)
-    ("U" "unstar" igist-unstar-gist :inapt-if-not tabulated-list-get-id)
+    ("v" "View" igist-list-view-current :inapt-if-not tabulated-list-get-id)
+    ("f" "Fork" igist-fork-gist :inapt-if-not igist-forkable)
+    ("w" "Copy Url" igist-copy-gist-url :inapt-if-not tabulated-list-get-id)
+    ("r" "Browse" igist-browse-gist :inapt-if-not tabulated-list-get-id)
+    ("S" "Star" igist-star-gist :inapt-if-not tabulated-list-get-id)
+    ("U" "Unstar" igist-unstar-gist :inapt-if-not tabulated-list-get-id)
     ("D" "Delete" igist-delete-current-gist :inapt-if-not igist-editable-p)
-    ("d" "description" igist-list-edit-description :inapt-if-not
-     igist-editable-p)]
+    ("d" "Description" igist-list-edit-description :inapt-if-not
+     tabulated-list-get-id)]
    [:if
     igist-edit-mode-p
     "Actions"
-    ("RET" "save" igist-save-current-gist :inapt-if-not igist-editable-p)
-    ("f" "fork" igist-fork-gist :inapt-if-not igist-forkable)
-    ("w" "copy url" igist-copy-gist-url :inapt-if-not igist-get-current-gist-url)
-    ("r" "browse" igist-browse-gist :inapt-if-not igist-get-current-gist-url)
-    ("S" "star" igist-star-gist :inapt-if-not igist-get-current-gist-id)
-    ("U" "unstar" igist-unstar-gist :inapt-if-not igist-get-current-gist-id)
+    ("RET" "Save" igist-save-current-gist :inapt-if-not igist-editable-p)
+    ("f" "Fork" igist-fork-gist :inapt-if-not igist-forkable)
+    ("w" "Copy url" igist-copy-gist-url :inapt-if-not igist-get-current-gist-url)
+    ("r" "Browse" igist-browse-gist :inapt-if-not igist-get-current-gist-url)
+    ("S" "Star" igist-star-gist :inapt-if-not igist-get-current-gist-id)
+    ("U" "Unstar" igist-unstar-gist :inapt-if-not igist-get-current-gist-id)
     ("D" "Delete" igist-delete-current-gist :inapt-if-not igist-editable-p)
-    ("R" igist-set-current-filename-variable)
     ("P" igist-transient-toggle-public)
+    ("R" igist-set-current-filename-variable)
     ("d" igist-set-current-description-variable)]
    ["List"
-    ("l" "my gists" igist-list-gists :inapt-if-nil igist-current-user-name)
-    ("m" "starred" igist-list-starred :inapt-if-nil igist-current-user-name)
+    ("l" "My gists" igist-list-gists :inapt-if-nil igist-current-user-name)
+    ("m" "Starred" igist-list-starred :inapt-if-nil igist-current-user-name)
     ("E" "Explore" igist-explore-public-gists :inapt-if
      igist-current-buffer-explore-p)
-    ("o" "other user" igist-list-other-user-gists)
-    ("g" "refresh" igist-list-refresh :inapt-if-not-derived igist-list-mode)
-    ("K" "cancel load" igist-list-cancel-load :inapt-if-not-derived
+    ("o" "Other user" igist-list-other-user-gists)
+    ("g" "Refresh" igist-list-refresh :inapt-if-not-derived igist-list-mode)
+    ("K" "Cancel load" igist-list-cancel-load :inapt-if-not-derived
      igist-list-mode)
-    ("X" "Kill buffers" igist-kill-all-gists-buffers)]]
+    ("X" "Kill buffers" igist-kill-all-gists-buffers)]
+   [:if-not-mode
+    igist-list-mode
+    "Create"
+    ("n" "New" igist-create-new-gist :inapt-if-nil igist-current-user-name)
+    ("b" "New from buffer" igist-new-gist-from-buffer :inapt-if-nil
+     igist-current-user-name)]]
   [:if-non-nil
    igist-current-gist
    ["Files"
-    ("-" "delete" igist-delete-current-filename :inapt-if-not
+    ("-" "Delete" igist-delete-current-filename :inapt-if-not
      igist-get-current-gist-url)
-    ("+" "add" igist-add-file-to-gist :inapt-if-not igist-get-current-gist-url)]
+    ("+" "Add" igist-add-file-to-gist :inapt-if-not igist-get-current-gist-url)]
    ["Comments"
-    ("a" "add" igist-add-comment  :inapt-if-not igist-get-current-gist-url)
-    ("c" "show" igist-load-comments  :inapt-if-not
+    ("a" "Add" igist-add-comment  :inapt-if-not igist-get-current-gist-url)
+    ("c" "Show" igist-load-comments  :inapt-if-not
      igist-get-current-gist-url)
-    ("e" "edit" igist-add-or-edit-comment :inapt-if-not
+    ("e" "Edit" igist-add-or-edit-comment :inapt-if-not
      igist-get-comment-id-at-point)]]
   [:if-mode
    igist-list-mode
    ["Create"
-    ("n" "new" igist-create-new-gist :inapt-if-nil igist-current-user-name)
-    ("b" "new from buffer" igist-new-gist-from-buffer :inapt-if-nil
+    ("n" "New" igist-create-new-gist :inapt-if-nil igist-current-user-name)
+    ("b" "New from buffer" igist-new-gist-from-buffer :inapt-if-nil
      igist-current-user-name)]
    ["Files"
-    ("+" "add" igist-list-add-file :inapt-if-not igist-editable-p)
-    ("-" "delete" igist-delete-current-filename :inapt-if-not igist-editable-p)]
+    ("+" "Add" igist-list-add-file :inapt-if-not igist-editable-p)
+    ("-" "Delete" igist-delete-current-filename :inapt-if-not igist-editable-p)]
    ["Comments"
-    ("a" "add" igist-add-comment :inapt-if-not tabulated-list-get-id)
-    ("c" "show" igist-load-comments :inapt-if-not tabulated-list-get-id)]]
+    ("a" "Add" igist-add-comment :inapt-if-not tabulated-list-get-id)
+    ("c" "Show" igist-load-comments :inapt-if-not tabulated-list-get-id)]]
   [:if igist-comments-list-mode-p
        ["Comments"
-        ("a" "add" igist-add-comment :inapt-if-nil igist-current-user-name)
-        ("g" "reload" igist-load-comments :inapt-if-nil igist-current-user-name)
-        ("e" "edit" igist-add-or-edit-comment :inapt-if-not
+        ("a" "Add" igist-add-comment :inapt-if-nil igist-current-user-name)
+        ("g" "Reload" igist-load-comments :inapt-if-nil igist-current-user-name)
+        ("e" "Edit" igist-add-or-edit-comment :inapt-if-not
          igist-get-comment-id-at-point)
         ("D" "Delete" igist-delete-comment-at-point :inapt-if-not
          igist-get-comment-id-at-point)]]
-  [:if-not-mode
-   igist-list-mode
-   "Create"
-   ("n" "new" igist-create-new-gist :inapt-if-nil igist-current-user-name)
-   ("b" "new from buffer" igist-new-gist-from-buffer :inapt-if-nil
-    igist-current-user-name)]
   ["User"
    ("u" igist-set-current-user)
    ("q" "Quit" transient-quit-all)])

--- a/igist.el
+++ b/igist.el
@@ -958,14 +958,19 @@ GIST should be raw GitHub item."
 (defun igist-list-edit-description (&rest _)
   "Edit description for current gist."
   (interactive)
-  (when-let* ((gist (igist-tabulated-gist-at-point))
-              (description (read-string "Description: " (igist-alist-get
-                                                         'description gist))))
-    (igist-patch (concat "/gists/" (igist-alist-get 'id gist))
-                 nil
-                 :payload `((description . ,description))
-                 :callback (lambda (&rest _)
-                             (igist-load-logged-user-gists)))))
+  (if-let ((gist (igist-tabulated-gist-at-point)))
+      (let ((description (igist-alist-get
+                          'description gist)))
+        (if (igist-editable-p gist)
+            (igist-patch (concat "/gists/" (igist-alist-get 'id gist))
+                         nil
+                         :payload `((description . ,(read-string "Description: "
+                                                                 description)))
+                         :callback (lambda (&rest _)
+                                     (igist-load-logged-user-gists)))
+          (message (or description
+                       "No description"))))
+    (user-error "No gist at point")))
 
 (defun igist-read-filename-new (gist)
   "Read a filename that doesn't exist in GIST."

--- a/igist.el
+++ b/igist.el
@@ -1954,9 +1954,10 @@ REQ is a `ghub--req' struct, used for loading next page."
       (with-current-buffer buffer
         (let ((fn (buffer-local-value 'igist-list-cancelled buffer)))
           (setq-local igist-list-response value)
+          (setq igist-list-loading nil)
           (setq igist-list-cancelled nil)
           (when (functionp fn)
-            (funcall igist-list-cancelled)))
+            (funcall fn)))
         (setq igist-list-loading nil)
         (when (timerp igist-render-timer)
           (cancel-timer igist-render-timer)
@@ -2070,8 +2071,8 @@ If BACKGROUND is nil, don't show user's buffer."
                             (igist-list-loaded-callback buffer value req
                                                         callback
                                                         callback-args)
-                          (setq igist-list-cancelled nil)
-                          (setq igist-list-loading nil))))
+                          (error (setq igist-list-cancelled nil)
+                                 (setq igist-list-loading nil)))))
         (unless background
           (igist-ensure-buffer-visible buffer))))))
 

--- a/igist.el
+++ b/igist.el
@@ -567,15 +567,16 @@ Result: \"JOHNjohn\"."
 
 (defun igist-editable-p (&optional gist)
   "Check whether user `igist-current-user-name' can edit GIST."
-  (when-let* ((id (and igist-current-user-name
-                       (igist-alist-get 'id (or gist
-                                                (igist-tabulated-gist-at-point)
-                                                igist-current-gist))))
-              (buffer (igist-get-user-buffer igist-current-user-name)))
-    (igist-alist-find-by-prop 'id id
-                              (when (buffer-live-p buffer)
-                                (buffer-local-value
-                                 'igist-list-response buffer)))))
+  (and igist-current-user-name
+       (cond ((eq major-mode 'igist-list-mode)
+              (when-let ((owner (igist-get-owner
+                                 (or gist (igist-tabulated-gist-at-point)))))
+                (equal igist-current-user-name owner)))
+             ((igist-edit-mode-p)
+              (if-let ((owner (igist-get-owner
+                               (or gist igist-current-gist))))
+                  (equal igist-current-user-name owner)
+                t)))))
 
 (defun igist-not-editable-p (&optional gist)
   "Return t if user `igist-current-user-name' cannot edit GIST."

--- a/igist.el
+++ b/igist.el
@@ -328,9 +328,6 @@ Should accept the same arguments as `message'."
 (defvar igist-current-user-name nil
   "The GitHub user to make authorized requests.")
 
-(defvar igist-other-username nil
-  "The GitHub user to load public gists.")
-
 (defcustom igist-auth-marker 'igist
   "Github OAuth token or suffix added to the USERNAME^MARKER in authsources.
 
@@ -2530,15 +2527,6 @@ If ACTION is non nil, call it with gist."
   :reader #'igist-change-user
   :argument "--user=")
 
-(transient-define-argument igist-transient-change-owner ()
-  "Change user whose gists to fetch."
-  :description "Other user"
-  :class 'transient-lisp-variable
-  :shortarg "-o"
-  :reader #'igist-list-change-other-user
-  :variable 'igist-other-username
-  :argument "--owner")
-
 (transient-define-argument igist-set-current-description-variable ()
   "Read description and assign it in the variable `igist-current-description'."
   :description "Description"
@@ -2568,7 +2556,8 @@ If ACTION is non nil, call it with gist."
   [[:if-mode
     igist-list-mode
     "Actions"
-    ("RET" "edit" igist-list-edit-gist-at-point :inapt-if-not tabulated-list-get-id)
+    ("RET" "edit" igist-list-edit-gist-at-point :inapt-if-not
+     tabulated-list-get-id)
     ("v" "view" igist-list-view-current :inapt-if-not tabulated-list-get-id)
     ("f" "fork" igist-fork-gist :inapt-if-not igist-forkable)
     ("w" "copy url" igist-copy-gist-url :inapt-if-not tabulated-list-get-id)
@@ -2576,7 +2565,8 @@ If ACTION is non nil, call it with gist."
     ("S" "star" igist-star-gist :inapt-if-not tabulated-list-get-id)
     ("U" "unstar" igist-unstar-gist :inapt-if-not tabulated-list-get-id)
     ("D" "Delete" igist-delete-current-gist :inapt-if-not igist-editable-p)
-    ("d" "description" igist-list-edit-description :inapt-if-not igist-editable-p)]
+    ("d" "description" igist-list-edit-description :inapt-if-not
+     igist-editable-p)]
    [:if
     igist-edit-mode-p
     "Actions"
@@ -2591,22 +2581,27 @@ If ACTION is non nil, call it with gist."
     ("P" igist-transient-toggle-public)
     ("d" igist-set-current-description-variable)]
    ["List"
-    ("l" "list my gists" igist-list-gists :inapt-if-nil igist-current-user-name)
-    ("m" "list my starrred gists" igist-list-starred :inapt-if-nil igist-current-user-name)
-    ("E" "Explore" igist-explore-public-gists :inapt-if igist-current-buffer-explore-p)
+    ("l" "my gists" igist-list-gists :inapt-if-nil igist-current-user-name)
+    ("m" "starred" igist-list-starred :inapt-if-nil igist-current-user-name)
+    ("E" "Explore" igist-explore-public-gists :inapt-if
+     igist-current-buffer-explore-p)
+    ("o" "other user" igist-list-other-user-gists)
     ("g" "refresh" igist-list-refresh :inapt-if-not-derived igist-list-mode)
-    ("K" "cancel load" igist-list-cancel-load :inapt-if-not-derived igist-list-mode)
+    ("K" "cancel load" igist-list-cancel-load :inapt-if-not-derived
+     igist-list-mode)
     ("X" "Kill buffers" igist-kill-all-gists-buffers)]]
   [:if-non-nil
    igist-current-gist
    ["Files"
-    ("-" "delete" igist-delete-current-filename :inapt-if-not igist-get-current-gist-url)
+    ("-" "delete" igist-delete-current-filename :inapt-if-not
+     igist-get-current-gist-url)
     ("+" "add" igist-add-file-to-gist :inapt-if-not igist-get-current-gist-url)]
    ["Comments"
     ("a" "add" igist-add-comment  :inapt-if-not igist-get-current-gist-url)
     ("c" "show" igist-load-comments  :inapt-if-not
      igist-get-current-gist-url)
-    ("e" "edit" igist-add-or-edit-comment :inapt-if-not igist-get-comment-id-at-point)]]
+    ("e" "edit" igist-add-or-edit-comment :inapt-if-not
+     igist-get-comment-id-at-point)]]
   [:if-mode
    igist-list-mode
    ["Create"
@@ -2620,21 +2615,22 @@ If ACTION is non nil, call it with gist."
     ("a" "add" igist-add-comment :inapt-if-not tabulated-list-get-id)
     ("c" "show" igist-load-comments :inapt-if-not tabulated-list-get-id)]]
   [:if igist-comments-list-mode-p
-   ["Comments"
-    ("a" "add" igist-add-comment :inapt-if-nil igist-current-user-name)
-    ("g" "reload" igist-load-comments :inapt-if-nil igist-current-user-name)
-    ("e" "edit" igist-add-or-edit-comment :inapt-if-not igist-get-comment-id-at-point)
-    ("D" "Delete" igist-delete-comment-at-point :inapt-if-not igist-get-comment-id-at-point)]]
+       ["Comments"
+        ("a" "add" igist-add-comment :inapt-if-nil igist-current-user-name)
+        ("g" "reload" igist-load-comments :inapt-if-nil igist-current-user-name)
+        ("e" "edit" igist-add-or-edit-comment :inapt-if-not
+         igist-get-comment-id-at-point)
+        ("D" "Delete" igist-delete-comment-at-point :inapt-if-not
+         igist-get-comment-id-at-point)]]
   [:if-not-mode
    igist-list-mode
    "Create"
    ("n" "new" igist-create-new-gist :inapt-if-nil igist-current-user-name)
-   ("b" "new from buffer" igist-new-gist-from-buffer :inapt-if-nil igist-current-user-name)]
+   ("b" "new from buffer" igist-new-gist-from-buffer :inapt-if-nil
+    igist-current-user-name)]
   ["User"
    ("u" igist-set-current-user)
-   ("o" igist-transient-change-owner)
    ("q" "Quit" transient-quit-all)])
-
 
 (provide 'igist)
 ;;; igist.el ends here

--- a/igist.el
+++ b/igist.el
@@ -1886,6 +1886,7 @@ If WITH-HEADING is non nil, include also heading, otherwise only body."
                                              'yes-or-no-p "Delete comment?")
               (yes-or-no-p "Delete comment?"))
         (igist-delete (format "/gists/%s/comments/%s" gist-id comment-id)
+                      nil
                       :callback (lambda (&rest _)
                                   (igist-with-exisiting-buffer
                                       (concat "*" gist-id

--- a/igist.el
+++ b/igist.el
@@ -896,6 +896,18 @@ GIST should be raw GitHub item."
                    (igist-alist-get 'files gist))))
     (cdr (igist-normalize-gist-file gist filename))))
 
+
+;;;###autoload
+(defun igist-copy-gist-url ()
+  "Copy url of gist at point or currently open."
+  (interactive)
+  (when-let ((gist-url
+              (igist-alist-get 'html_url
+                               (or (igist-tabulated-gist-at-point)
+                                   igist-current-gist))))
+    (kill-new gist-url)
+    (message "Copied %s" gist-url)))
+
 ;;;###autoload
 (defun igist-browse-gist ()
   "Browse gist at point or currently open."

--- a/igist.el
+++ b/igist.el
@@ -1383,7 +1383,7 @@ If LOADING is non nil show spinner, otherwise hide."
                                        '(t after-update))
                              (when-let ((url (igist-get-current-gist-url)))
                                (kill-new url)
-                               (igist-message "Copied %s" url)))
+                               (message "Copied %s" url)))
                            (when callback
                              (funcall callback))))
                      (igist-message "Couldn't save gist."))))))
@@ -2264,7 +2264,7 @@ With CALLBACK call it without args after success request."
   (igist-save-gist-buffer (current-buffer)
                           (lambda ()
                             (kill-buffer (buffer-name))
-                            (igist-message "Gist created"))))
+                            (igist-message "Gist saved"))))
 
 (defun igist-completing-read-gists (&optional prompt action initial-input)
   "Read gist in minibuffer with PROMPT and INITIAL-INPUT.

--- a/igist.el
+++ b/igist.el
@@ -1679,10 +1679,11 @@ MAX is length of most longest key."
                              (igist--get-time (igist-alist-get 'updated_at
                                                                comment-alist))))
         (author (alist-get 'login (alist-get 'user comment-alist))))
-    (propertize (format "# Comment (%s at %s)\n%s" author updated comment)
-                'igist-comment-id comment-id
-                'igist-comment-gist-id gist-id
-                'igist-gist-author author)))
+    (propertize
+     (format "## **%s** commented on %s\n\n%s" author updated comment)
+     'igist-comment-id comment-id
+     'igist-comment-gist-id gist-id
+     'igist-gist-author author)))
 
 ;;;###autoload
 (define-minor-mode igist-comments-list-mode

--- a/igist.el
+++ b/igist.el
@@ -793,11 +793,13 @@ have the same meaning, as in `ghub-request'."
 
 (defun igist-set-major-mode (filename)
   "Guess major mode for FILENAME."
-  (let ((buffer-file-name (expand-file-name filename default-directory)))
-    (delay-mode-hooks
-      (ignore-errors
-        (set-auto-mode)
-        (font-lock-ensure)))))
+  (let ((buffer-file-name (or
+                           (if (file-name-absolute-p filename)
+                               filename
+                             (expand-file-name filename default-directory)))))
+    (ignore-errors
+      (set-auto-mode)
+      (font-lock-ensure))))
 
 (defun igist-list-jump-to-entry-start ()
   "Goto entry start."


### PR DESCRIPTION
- Add commands for starring gists: `igist-star-gist`, `igist-unstar-gist` and `igist-list-starred`
- Add custom variable `igist-enable-copy-gist-url` to control whether to copy gists URL after creating or editing
- Update layout and keys for transient. Transient commands are now bound to single keys.
- Change keybinding for `igist-browse-gist` from `b` to `r`
- Remove separate variable for another user name as it can be accessed from `igist-list-other-user-gists` history
- Setup temporarly `buffer-file-name` for gists in edit buffers.
- Allow major mode hooks in edit mode.
- Run `before-save-hook` before posting gists
- Speedup `igist-explore-public-gists`
- Fix removing comments
- Fix running `igist-before-save-hook`